### PR TITLE
Context menu to display the axis labels.

### DIFF
--- a/GUI/PlotPanel.cs
+++ b/GUI/PlotPanel.cs
@@ -33,6 +33,7 @@ namespace OpenHardwareMonitor.GUI {
       new SortedDictionary<SensorType, LinearAxis>();
 
     private UserOption stackedAxes;
+    private UserOption axisLabels;
 
     private DateTime now;
 
@@ -78,6 +79,14 @@ namespace OpenHardwareMonitor.GUI {
         InvalidatePlot();
       };
       menu.MenuItems.Add(stackedAxesMenuItem);
+
+      MenuItem axisLabelsMenuItem = new MenuItem("Axis Labels");
+      axisLabels = new UserOption("axisLabels", true,
+        axisLabelsMenuItem, settings);
+      axisLabels.Changed += (sender, e) => {
+        model.PlotMargins = ((UserOption)sender).Value ? new OxyThickness(double.NaN) : new OxyThickness(0);
+      };
+      menu.MenuItems.Add(axisLabelsMenuItem);
 
       MenuItem timeWindow = new MenuItem("Time Window");
       MenuItem[] timeWindowMenuItems =


### PR DESCRIPTION
The labels were there, just not visible. I just added a context menu to toggle the margin auto-size feature which will display the labels as expected.

Issue #2.

// Summary:
//     Gets or sets the margins around the plot (this should be large enough to fit
//     the axes). If any of the values is set to double.NaN, the margin is adjusted
//     to the value required by the axes.