### PR TITLE
Add logging to identify internal errors

### DIFF
--- a/OpenHardwareMonitor/GUI/AboutBox.cs
+++ b/OpenHardwareMonitor/GUI/AboutBox.cs
@@ -14,6 +14,8 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
 using System.Windows.Forms;
+using Microsoft.Extensions.Logging;
+using OpenHardwareMonitorLib;
 
 namespace OpenHardwareMonitor.GUI {
   public partial class AboutBox : Form {
@@ -36,7 +38,9 @@ namespace OpenHardwareMonitor.GUI {
       LinkLabelLinkClickedEventArgs e) {
       try {
         Process.Start(new ProcessStartInfo(e.Link.LinkData.ToString()));
-      } catch { }
+      } catch (Exception x) {
+        this.GetCurrentClassLogger().LogError(x, "Unable to launch browser");
+      }
     }
 
   }

--- a/OpenHardwareMonitor/NLog.config
+++ b/OpenHardwareMonitor/NLog.config
@@ -1,0 +1,35 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.nlog-project.org/schemas/NLog.xsd NLog.xsd"
+      autoReload="true"
+      throwExceptions="false"
+      internalLogLevel="Off" internalLogFile="c:\temp\nlog-internal.log">
+
+  <!--
+  See https://github.com/nlog/nlog/wiki/Configuration-file
+  for information on customizing logging rules and outputs.
+   -->
+  <targets>
+
+    <!--
+    add your targets here
+    See https://github.com/nlog/NLog/wiki/Targets for possible targets.
+    See https://github.com/nlog/NLog/wiki/Layout-Renderers for the possible layout renderers.
+    -->
+
+    <!--
+    Write events to a file with the date in the filename. -->
+    <target xsi:type="File" name="logFile" fileName="${tempdir}/OHM_${shortdate}.log"
+            layout="${longdate}|${level}|${logger}|${message}|${exception:format=tostring}" />
+    <target name="DebugOutput" xsi:type="OutputDebugString" layout="${longdate:universalTime=true}|${ticks}|${threadid}|${level}|${logger}: ${message} ${exception}${newline}" />
+  </targets>
+
+  <rules>
+    <!-- add your logging rules here -->
+
+    <!-- Write all events with minimal level of Debug (So Debug, Info, Warn, Error and Fatal, but not Trace)  to "logFile" -->
+    <logger name="*" minlevel="Debug" writeTo="logFile" />
+    <logger name="*" minlevel="Debug" writeTo="DebugOutput" />
+  </rules>
+</nlog>

--- a/OpenHardwareMonitor/NLog.config
+++ b/OpenHardwareMonitor/NLog.config
@@ -21,7 +21,9 @@
     <!--
     Write events to a file with the date in the filename. -->
     <target xsi:type="File" name="logFile" fileName="${tempdir}/OHM_${shortdate}.log"
-            layout="${longdate}|${level}|${logger}|${message}|${exception:format=tostring}" />
+            layout="${longdate}|${level}|${logger}|${message}|${exception:format=tostring}" encoding="utf-8" writeBom="true"
+            maxArchiveFiles="4"
+            archiveAboveSize="100000" />
     <target name="DebugOutput" xsi:type="OutputDebugString" layout="${longdate:universalTime=true}|${ticks}|${threadid}|${level}|${logger}: ${message} ${exception}${newline}" />
   </targets>
 

--- a/OpenHardwareMonitor/OpenHardwareMonitor.csproj
+++ b/OpenHardwareMonitor/OpenHardwareMonitor.csproj
@@ -87,6 +87,8 @@
   <ItemGroup>
     <PackageReference Include="AdamsLair.TreeViewAdv" Version="1.7.7" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
+    <PackageReference Include="NLog" Version="4.7.10" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="1.7.3" />
     <PackageReference Include="OxyPlot.WindowsForms" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>
@@ -95,5 +97,10 @@
   <ItemGroup>
     <Reference Include="System.Configuration.Install" />
     <Reference Include="System.Management" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="NLog.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/OpenHardwareMonitor/Program.cs
+++ b/OpenHardwareMonitor/Program.cs
@@ -16,8 +16,10 @@ using System.Text;
 using System.Threading;
 using System.Windows.Forms;
 using CommandLine;
+using Microsoft.Extensions.Logging;
 using OpenHardwareMonitor.GUI;
 using OpenHardwareMonitor.Utilities;
+using OpenHardwareMonitorLib;
 
 namespace OpenHardwareMonitor {
   public static class Program {
@@ -37,6 +39,8 @@ namespace OpenHardwareMonitor {
       if (!AllRequiredFilesAvailable() || !IsNetFramework45Installed())
         Environment.Exit(0);
 
+      InstallAndConfigureNlog();
+
       ParseCommandLine(args);
       Application.EnableVisualStyles();
       Application.SetCompatibleTextRenderingDefault(false);
@@ -46,6 +50,11 @@ namespace OpenHardwareMonitor {
         };        
         Application.Run();
       }
+    }
+
+    private static void InstallAndConfigureNlog() {
+      Logging.LoggerFactory = new ToNLogLoggerFactory();
+      Logging.LogInfo("Starting new session");
     }
 
     private static void ParseCommandLine(string[] args) {
@@ -148,6 +157,17 @@ namespace OpenHardwareMonitor {
       } finally {
         Environment.Exit(0);
       }
-    }   
+    }
+
+    private sealed class ToNLogLoggerFactory : ILoggerFactory {
+      public void Dispose() {
+      }
+
+      public ILogger CreateLogger(string categoryName) {
+        return new NLog.Extensions.Logging.NLogLoggerFactory().CreateLogger(categoryName);
+      }
+
+      public void AddProvider(ILoggerProvider provider) => throw new NotImplementedException();
+    }
   }
 }

--- a/OpenHardwareMonitorLib/Hardware/ATI/ADL.cs
+++ b/OpenHardwareMonitorLib/Hardware/ATI/ADL.cs
@@ -11,6 +11,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
+using OpenHardwareMonitorLib;
 
 namespace OpenHardwareMonitor.Hardware.ATI {
   
@@ -493,12 +494,14 @@ namespace OpenHardwareMonitor.Hardware.ATI {
         try {
           return _ADL_Main_Control_Create(Main_Memory_Alloc,
             enumConnectedAdapters);
-        } catch {
+        } catch (Exception x){
+          Logging.LogError(x, "Unable to open ADL_Main_Control using atiadlxx");
           CreateDelegates("atiadlxy");
           return _ADL_Main_Control_Create(Main_Memory_Alloc,
             enumConnectedAdapters);
         }
-      } catch {
+      } catch (Exception x) {
+        Logging.LogError(x, "Unable to open ADL_Main_Control using atiadlxy");
         return ADLStatus.ERR;
       }
     }
@@ -512,11 +515,12 @@ namespace OpenHardwareMonitor.Hardware.ATI {
         if (result != ADLStatus.OK)
           context = IntPtr.Zero;
         return result;
-      } catch {
+      } catch(Exception x) {
+        Logging.LogError(x, "Unable to open ADL2_Main_Control");
         context = IntPtr.Zero;
         return ADLStatus.ERR;
       }
-     }
+    }
 
     public static ADLStatus ADL_Adapter_AdapterInfo_Get(ADLAdapterInfo[] info) {
       int elementSize = Marshal.SizeOf(typeof(ADLAdapterInfo));
@@ -552,10 +556,12 @@ namespace OpenHardwareMonitor.Hardware.ATI {
       out int adapterID) {
       try {
         return _ADL_Adapter_ID_Get(adapterIndex, out adapterID);
-      } catch (EntryPointNotFoundException) {
+      } catch (EntryPointNotFoundException e1) {
+        Logging.LogError(e1, "Unable to get entry point for ADL_Adapter_ID_Get");
         try {
           return _ADL_Display_AdapterID_Get(adapterIndex, out adapterID);
-        } catch (EntryPointNotFoundException) {
+        } catch (EntryPointNotFoundException e2) {
+          Logging.LogError(e2, "Unable to get entry point for ADL_Display_AdapterID_Get");
           adapterID = 1;
           return ADLStatus.OK;
         }

--- a/OpenHardwareMonitorLib/Hardware/ATI/ATIGPU.cs
+++ b/OpenHardwareMonitorLib/Hardware/ATI/ATIGPU.cs
@@ -578,14 +578,17 @@ namespace OpenHardwareMonitor.Hardware.ATI {
       }
     }
 
-    public override void Close() {
-      this.fanControl.ControlModeChanged -= ControlModeChanged;
-      this.fanControl.SoftwareControlValueChanged -=
-        SoftwareControlValueChanged;
+    protected override void Dispose(bool disposing) {
+      if (disposing) {
+        this.fanControl.ControlModeChanged -= ControlModeChanged;
+        this.fanControl.SoftwareControlValueChanged -=
+          SoftwareControlValueChanged;
 
-      if (this.fanControl.ControlMode != ControlMode.Undefined)
-        SetDefaultFanSpeed();
-      base.Close();
+        if (this.fanControl.ControlMode != ControlMode.Undefined)
+          SetDefaultFanSpeed();
+      }
+
+      base.Dispose(disposing);
     }
   }
 }

--- a/OpenHardwareMonitorLib/Hardware/ATI/ATIGroup.cs
+++ b/OpenHardwareMonitorLib/Hardware/ATI/ATIGroup.cs
@@ -147,7 +147,7 @@ namespace OpenHardwareMonitor.Hardware.ATI {
     public void Close() {
       try {
         foreach (ATIGPU gpu in hardware)
-          gpu.Close();
+          gpu.Dispose();
 
         if (context != IntPtr.Zero) {
           ADL.ADL2_Main_Control_Destroy(context);

--- a/OpenHardwareMonitorLib/Hardware/CPU/AMD10CPU.cs
+++ b/OpenHardwareMonitorLib/Hardware/CPU/AMD10CPU.cs
@@ -397,11 +397,11 @@ namespace OpenHardwareMonitor.Hardware.CPU {
       }
     }
 
-    public override void Close() {      
+    protected override void Dispose(bool disposing) {
       if (temperatureStream != null) {
         temperatureStream.Close();
       }
-      base.Close();
+      base.Dispose(disposing);
     }
   }
 }

--- a/OpenHardwareMonitorLib/Hardware/CPU/CPUGroup.cs
+++ b/OpenHardwareMonitorLib/Hardware/CPU/CPUGroup.cs
@@ -198,7 +198,7 @@ namespace OpenHardwareMonitor.Hardware.CPU {
 
     public void Close() {
       foreach (GenericCPU cpu in hardware) {
-        cpu.Close();
+        cpu.Dispose();
       }
     }
   }

--- a/OpenHardwareMonitorLib/Hardware/Computer.cs
+++ b/OpenHardwareMonitorLib/Hardware/Computer.cs
@@ -61,8 +61,10 @@ namespace OpenHardwareMonitor.Hardware {
       groups.Remove(group);
 
       if (HardwareRemoved != null)
-        foreach (IHardware hardware in group.Hardware)
+        foreach (IHardware hardware in group.Hardware) {
           HardwareRemoved(hardware);
+          hardware.Dispose();
+        }
 
       group.Close();
     }

--- a/OpenHardwareMonitorLib/Hardware/HDD/AbstractHarddrive.cs
+++ b/OpenHardwareMonitorLib/Hardware/HDD/AbstractHarddrive.cs
@@ -284,9 +284,9 @@ namespace OpenHardwareMonitor.Hardware.HDD {
       return (raw[3] << 24) | (raw[2] << 16) | (raw[1] << 8) | raw[0];
     }
 
-    public override void Close() {
+    protected override void Dispose(bool disposing) {
       smart.Close();
-      base.Close();
+      base.Dispose(disposing);
     }
   }
 }

--- a/OpenHardwareMonitorLib/Hardware/HDD/AbstractHarddrive.cs
+++ b/OpenHardwareMonitorLib/Hardware/HDD/AbstractHarddrive.cs
@@ -103,12 +103,12 @@ namespace OpenHardwareMonitor.Hardware.HDD {
       if (string.IsNullOrEmpty(firmwareRevision))
         firmwareRevision = string.IsNullOrEmpty(info.Revision) ? "Unknown" : info.Revision;
 
-      Logging.LogInfo($"Attempting to initialize sensor instance for {info.Name}");
-
       if (logicalDrives.Any()) {
         logicalDrives = logicalDrives.Select(x => $"{x}:");
         name += " (" + string.Join(", ", logicalDrives) + ")";
       }
+
+      Logging.LogInfo($"Attempting to initialize sensor instance for {name}");
 
       foreach (Type type in hddTypes) {
         // get the array of name prefixes for the current type
@@ -137,7 +137,7 @@ namespace OpenHardwareMonitor.Hardware.HDD {
 
         // if an attribute is missing, then try the next type
         if (!allRequiredAttributesFound)
-          continue;        
+          continue;
 
         // check if there is a matching name prefix for this type
         foreach (NamePrefixAttribute prefix in namePrefixes) {

--- a/OpenHardwareMonitorLib/Hardware/HDD/AbstractStorage.cs
+++ b/OpenHardwareMonitorLib/Hardware/HDD/AbstractStorage.cs
@@ -65,6 +65,16 @@ namespace OpenHardwareMonitor.Hardware.HDD {
       smart = new WindowsSmart(index);
     }
 
+    protected override void Dispose(bool disposing) {
+      if (disposing) {
+        if (smart != null) {
+          smart.Dispose();
+          smart = null;
+        }
+      }
+      base.Dispose(disposing);
+    }
+
     public static AbstractStorage CreateInstance(int driveNumber, NVMeGeneric previousNvMe, ISettings settings) {
       StorageInfo info = WindowsStorage.GetStorageInfo(driveNumber);
       if (info == null) {

--- a/OpenHardwareMonitorLib/Hardware/HDD/AbstractStorage.cs
+++ b/OpenHardwareMonitorLib/Hardware/HDD/AbstractStorage.cs
@@ -72,11 +72,22 @@ namespace OpenHardwareMonitor.Hardware.HDD {
         return null;
       }
 
-      if (info.BusType == StorageBusType.BusTypeAta || info.BusType == StorageBusType.BusTypeSata)
-        return ATAStorage.CreateInstance(info, settings);
-      if (info.BusType == StorageBusType.BusTypeNvme)
-        return NVMeGeneric.CreateInstance(info, previousNvMe, settings);
-      return StorageGeneric.CreateInstance(info, settings);
+      AbstractStorage ret = null;
+      if (info.BusType == StorageBusType.BusTypeNvme) {
+        ret = NVMeGeneric.CreateInstance(info, previousNvMe, settings);
+      }
+
+      // If the disk uses Nvme, but does not support the required interfaces, we try Sata instead.
+      if (ret == null && (info.BusType == StorageBusType.BusTypeAta || info.BusType == StorageBusType.BusTypeSata ||
+                          info.BusType == StorageBusType.BusTypeNvme)) {
+        ret = ATAStorage.CreateInstance(info, settings);
+      }
+
+      if (ret == null) {
+        ret = StorageGeneric.CreateInstance(info, settings);
+      }
+
+      return ret;
     }
 
     protected virtual void CreateSensors() {

--- a/OpenHardwareMonitorLib/Hardware/HDD/AbstractStorage.cs
+++ b/OpenHardwareMonitorLib/Hardware/HDD/AbstractStorage.cs
@@ -17,6 +17,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using Microsoft.Extensions.Logging;
+using OpenHardwareMonitorLib;
 
 namespace OpenHardwareMonitor.Hardware.HDD {
   internal abstract class AbstractStorage : Hardware {
@@ -66,8 +67,11 @@ namespace OpenHardwareMonitor.Hardware.HDD {
 
     public static AbstractStorage CreateInstance(int driveNumber, NVMeGeneric previousNvMe, ISettings settings) {
       StorageInfo info = WindowsStorage.GetStorageInfo(driveNumber);
-      if (info == null || info.Removable)
+      if (info == null) {
+        Logging.LogInfo($"Could not retrieve storage information for drive number {driveNumber}");
         return null;
+      }
+
       if (info.BusType == StorageBusType.BusTypeAta || info.BusType == StorageBusType.BusTypeSata)
         return ATAStorage.CreateInstance(info, settings);
       if (info.BusType == StorageBusType.BusTypeNvme)

--- a/OpenHardwareMonitorLib/Hardware/HDD/HarddriveGroup.cs
+++ b/OpenHardwareMonitorLib/Hardware/HDD/HarddriveGroup.cs
@@ -55,7 +55,7 @@ namespace OpenHardwareMonitor.Hardware.HDD {
 
     public void Close() {
       foreach (AbstractStorage hdd in hardware) 
-        hdd.Close();
+        hdd.Dispose();
     }
   }
 }

--- a/OpenHardwareMonitorLib/Hardware/HDD/NVMeGeneric.cs
+++ b/OpenHardwareMonitorLib/Hardware/HDD/NVMeGeneric.cs
@@ -180,10 +180,10 @@ namespace OpenHardwareMonitor.Hardware.HDD {
       }
     }
 
-    public override void Close() {
-      smart.Close();
+    protected override void Dispose(bool disposing) {
+      smart.Dispose();
 
-      base.Close();
+      base.Dispose(disposing);
     }
   }
 }

--- a/OpenHardwareMonitorLib/Hardware/HDD/NVMeGeneric.cs
+++ b/OpenHardwareMonitorLib/Hardware/HDD/NVMeGeneric.cs
@@ -11,6 +11,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using OpenHardwareMonitorLib;
 
 namespace OpenHardwareMonitor.Hardware.HDD {
   internal sealed class NVMeGeneric : AbstractStorage {
@@ -57,13 +58,18 @@ namespace OpenHardwareMonitor.Hardware.HDD {
         }
       }
 
+      // This is a bit tricky. If this fails for one drive, it will fail for all, because we start with 0 each time.
+      // Could be irrelevant, though, because maybe the error depends on the main board or driver, not even the disk?
       return null;
     }
 
     public static AbstractStorage CreateInstance(StorageInfo storageInfo, NVMeGeneric previousNvme, ISettings settings) {
       NVMeInfo nvmeInfo = GetDeviceInfo(storageInfo, previousNvme != null ? previousNvme.info.LogicalDeviceNumber : -1);
-      if (nvmeInfo == null)
+      if (nvmeInfo == null) {
+        Logging.LogInfo($"Device {storageInfo.Index} ({storageInfo.Name}) identifies as NVMe device, but does not support all requires features.");
         return null;
+      }
+
       return new NVMeGeneric(nvmeInfo, storageInfo.Index, settings);
     }
 

--- a/OpenHardwareMonitorLib/Hardware/HDD/StorageGeneric.cs
+++ b/OpenHardwareMonitorLib/Hardware/HDD/StorageGeneric.cs
@@ -9,6 +9,8 @@
 */
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace OpenHardwareMonitor.Hardware.HDD {
@@ -20,6 +22,12 @@ namespace OpenHardwareMonitor.Hardware.HDD {
 
     public static AbstractStorage CreateInstance(StorageInfo info, ISettings settings) {
       string name = string.IsNullOrEmpty(info.Name) ? "Generic Hard Disk" : info.Name;
+      IEnumerable<string> logicalDrives = WindowsStorage.GetLogicalDrives(info.Index);
+      if (logicalDrives.Any()) {
+        logicalDrives = logicalDrives.Select(x => $"{x}:");
+        name += " (" + string.Join(", ", logicalDrives) + ")";
+      }
+
       string firmwareRevision = string.IsNullOrEmpty(info.Revision) ? "Unknown" : info.Revision;
       return new StorageGeneric(name, firmwareRevision, info.Index, settings);
     }

--- a/OpenHardwareMonitorLib/Hardware/HDD/WindowsNVMeSmart.cs
+++ b/OpenHardwareMonitorLib/Hardware/HDD/WindowsNVMeSmart.cs
@@ -81,6 +81,7 @@ namespace OpenHardwareMonitor.Hardware.HDD {
   internal class WindowsNVMeSmart : IDisposable {
     private enum Command : uint {
       IoctlScsiMiniPort = 0x04d008,
+      IOCTL_STORAGE_QUERY_PROPERTY = 0x002d1400,
     }
 
     private const string NVMeMiniPortSignature = "NvmeMini";
@@ -289,6 +290,13 @@ namespace OpenHardwareMonitor.Hardware.HDD {
     }
 
     private class NVMeInfoImpl : NVMeInfo {
+      // Used if the NVMeIdentifyControllerData is not available
+      public NVMeInfoImpl(int index, int logicalDeviceNumber, StorageInfo smart) {
+        Index = index;
+        LogicalDeviceNumber = logicalDeviceNumber;
+        Serial = smart.Serial;
+        Model = smart.Name;
+      }
       public NVMeInfoImpl(int index, int logicalDeviceNumber, NVMeIdentifyControllerData data, byte[] rawData) {
         Index = index;
         VID = data.vid;
@@ -397,6 +405,7 @@ namespace OpenHardwareMonitor.Hardware.HDD {
 
     private readonly SafeHandle handle;
     private int driveNumber;
+    private bool _requiresAlternateHealthInfo;
 
 #if DEBUG
     static WindowsNVMeSmart() {
@@ -409,6 +418,7 @@ namespace OpenHardwareMonitor.Hardware.HDD {
 
     public WindowsNVMeSmart(int driveNumber) {
       this.driveNumber = driveNumber;
+      _requiresAlternateHealthInfo = false;
       handle = NativeMethods.CreateFile(string.Format(@"\\.\Scsi{0}:", driveNumber), FileAccess.ReadWrite,
         FileShare.ReadWrite, IntPtr.Zero, FileMode.Open, FileAttributes.Normal, IntPtr.Zero);
     }
@@ -422,14 +432,14 @@ namespace OpenHardwareMonitor.Hardware.HDD {
       GC.SuppressFinalize(this);
     }
 
-    public NVMeInfo GetInfo(int logicalDriveNumber) {
+    public NVMeInfo GetInfo(StorageInfo infoToMatch, int logicalDriveNumber) {
       if (handle.IsClosed)
         throw new ObjectDisposedException("WindowsNVMeSmart");
       try {
         byte[] rawData;
         // This doesn't work with SCSI devices. Otherwise, that would be unique
         // var deviceNumber = WindowsStorage.QueryDeviceNumber(handle);
-        NVMeIdentifyControllerData data = ReadPassThrough<NVMeIdentifyControllerData>(NVMePassThroughOpcode.AdminIdentify, 0x00000000, 0x000000001, out rawData);
+        NVMeIdentifyControllerData data = ReadPassThrough<NVMeIdentifyControllerData>(NVMePassThroughOpcode.AdminIdentify, 0x0, 0x000000001, out rawData);
         if (data.nn == 1) {
           byte[] rawDataNamespace;
           NVMeIdentifyNamespaceData nspace = ReadPassThrough<NVMeIdentifyNamespaceData>(NVMePassThroughOpcode.AdminIdentify, 0x000000001, 0x00000000, out rawDataNamespace);
@@ -439,21 +449,75 @@ namespace OpenHardwareMonitor.Hardware.HDD {
       } catch (Win32Exception x) {
         Logging.LogError(x, "Unable to query NVMe controller info");
       }
-      return null;
+
+      // Construct the object anyway (or the counting will probably be off)
+      // Also, the device will probably support some NVMe commands anyway
+      return new NVMeInfoImpl(driveNumber, logicalDriveNumber, infoToMatch);
     }
 
     public NVMeHealthInfo GetHealthInfo() {
       if (handle.IsClosed)
         throw new ObjectDisposedException("WindowsNVMeSmart");
-      try {
-        uint size = (uint)Marshal.SizeOf(typeof(NVMeHealthInfoLog));
-        uint cdw10 = 0x000000002 | (((size / 4) - 1) << 16);
-        byte[] rawData;
-        NVMeHealthInfoLog data = ReadPassThrough<NVMeHealthInfoLog>(NVMePassThroughOpcode.AdminGetLogPage, 0xffffffff, cdw10, out rawData);
-        return new NVMeHealthInfoImpl(data, rawData);
-      } catch (Win32Exception) {
+      if (!_requiresAlternateHealthInfo) {
+        try {
+          uint size = (uint)Marshal.SizeOf(typeof(NVMeHealthInfoLog));
+          uint cdw10 = 0x000000002 | (((size / 4) - 1) << 16);
+          byte[] rawData;
+          NVMeHealthInfoLog data = ReadPassThrough<NVMeHealthInfoLog>(NVMePassThroughOpcode.AdminGetLogPage, 0xffffffff,
+            cdw10, out rawData);
+          return new NVMeHealthInfoImpl(data, rawData);
+        } catch (Win32Exception x) {
+          Logging.LogError(x, "Unable to query NVMe Health Information, trying alternate API");
+        }
       }
+
+      try {
+        NVMeHealthInfoLog data2;
+        if (GetHealthInfoAlternate(out data2)) {
+          // If this succeeds (and the above fails), always go directly here
+          _requiresAlternateHealthInfo = true;
+          return new NVMeHealthInfoImpl(data2, null);
+        }
+      } catch (Win32Exception x) {
+        Logging.LogError(x, "Alternate API doesn't work, either.");
+      }
+
+
       return null;
+    }
+
+    private bool GetHealthInfoAlternate(out NVMeHealthInfoLog data) {
+      data = NativeMethods.CreateStruct<NVMeHealthInfoLog>();
+      if (handle == null || handle.IsInvalid)
+        return false;
+
+      bool result = false;
+      NativeMethods.STORAGE_QUERY_BUFFER nptwb = NativeMethods.CreateStruct<NativeMethods.STORAGE_QUERY_BUFFER>();
+      nptwb.ProtocolSpecific.ProtocolType = NativeMethods.STORAGE_PROTOCOL_TYPE.ProtocolTypeNvme;
+      nptwb.ProtocolSpecific.DataType = (uint)NativeMethods.STORAGE_PROTOCOL_NVME_DATA_TYPE.NVMeDataTypeLogPage;
+      nptwb.ProtocolSpecific.ProtocolDataRequestValue = (uint)NativeMethods.NVME_LOG_PAGES.NVME_LOG_PAGE_HEALTH_INFO;
+      nptwb.ProtocolSpecific.ProtocolDataOffset = (uint)Marshal.SizeOf<NativeMethods.STORAGE_PROTOCOL_SPECIFIC_DATA>();
+      nptwb.ProtocolSpecific.ProtocolDataLength = (uint)nptwb.Buffer.Length;
+      nptwb.PropertyId = NativeMethods.STORAGE_PROPERTY_ID.StorageAdapterProtocolSpecificProperty;
+      nptwb.QueryType = NativeMethods.STORAGE_QUERY_TYPE.PropertyStandardQuery;
+
+      int length = Marshal.SizeOf<NativeMethods.STORAGE_QUERY_BUFFER>();
+      IntPtr buffer = Marshal.AllocHGlobal(length);
+      Marshal.StructureToPtr(nptwb, buffer, false);
+      bool validTransfer = NativeMethods.DeviceIoControl(handle, Command.IOCTL_STORAGE_QUERY_PROPERTY, buffer, length, buffer, length, out _, IntPtr.Zero);
+      if (validTransfer) {
+        //map NVME_HEALTH_INFO_LOG to nptwb.Buffer
+        IntPtr offset = Marshal.OffsetOf<NativeMethods.STORAGE_QUERY_BUFFER>(nameof(NativeMethods.STORAGE_QUERY_BUFFER.Buffer));
+        var newPtr = IntPtr.Add(buffer, offset.ToInt32());
+        NVMeHealthInfoLog item = Marshal.PtrToStructure<NVMeHealthInfoLog>(newPtr);
+        data = item;
+        Marshal.FreeHGlobal(buffer);
+        result = true;
+      } else {
+        Marshal.FreeHGlobal(buffer);
+      }
+
+      return result;
     }
 
     private T ReadPassThrough<T>(NVMePassThroughOpcode opcode, uint nsid, uint cdw10, out byte[] rawData) {
@@ -531,6 +595,117 @@ namespace OpenHardwareMonitor.Hardware.HDD {
         Command command, IntPtr dataIn, int dataInSize,
         IntPtr dataOut, int dataOutSize, out uint bytesReturned,
         IntPtr overlapped);
+
+      internal enum STORAGE_PROTOCOL_TYPE {
+        ProtocolTypeUnknown = 0x00,
+        ProtocolTypeScsi,
+        ProtocolTypeAta,
+        ProtocolTypeNvme,
+        ProtocolTypeSd,
+        ProtocolTypeProprietary = 0x7E,
+        ProtocolTypeMaxReserved = 0x7F
+      }
+
+      internal enum STORAGE_PROPERTY_ID {
+        StorageDeviceProperty = 0,
+        StorageAdapterProperty,
+        StorageDeviceIdProperty,
+        StorageDeviceUniqueIdProperty,
+        StorageDeviceWriteCacheProperty,
+        StorageMiniportProperty,
+        StorageAccessAlignmentProperty,
+        StorageDeviceSeekPenaltyProperty,
+        StorageDeviceTrimProperty,
+        StorageDeviceWriteAggregationProperty,
+        StorageDeviceDeviceTelemetryProperty,
+        StorageDeviceLBProvisioningProperty,
+        StorageDevicePowerProperty,
+        StorageDeviceCopyOffloadProperty,
+        StorageDeviceResiliencyProperty,
+        StorageDeviceMediumProductType,
+        StorageAdapterRpmbProperty,
+        StorageDeviceIoCapabilityProperty = 48,
+        StorageAdapterProtocolSpecificProperty,
+        StorageDeviceProtocolSpecificProperty,
+        StorageAdapterTemperatureProperty,
+        StorageDeviceTemperatureProperty,
+        StorageAdapterPhysicalTopologyProperty,
+        StorageDevicePhysicalTopologyProperty,
+        StorageDeviceAttributesProperty,
+        StorageDeviceManagementStatus,
+        StorageAdapterSerialNumberProperty,
+        StorageDeviceLocationProperty
+      }
+
+      internal enum STORAGE_QUERY_TYPE {
+        PropertyStandardQuery = 0,
+        PropertyExistsQuery,
+        PropertyMaskQuery,
+        PropertyQueryMaxDefined
+      }
+
+      internal enum STORAGE_PROTOCOL_NVME_DATA_TYPE {
+        NVMeDataTypeUnknown = 0,
+        NVMeDataTypeIdentify,
+        NVMeDataTypeLogPage,
+        NVMeDataTypeFeature
+      }
+
+      internal enum NVME_LOG_PAGES {
+        NVME_LOG_PAGE_ERROR_INFO = 0x01,
+        NVME_LOG_PAGE_HEALTH_INFO = 0x02,
+        NVME_LOG_PAGE_FIRMWARE_SLOT_INFO = 0x03,
+        NVME_LOG_PAGE_CHANGED_NAMESPACE_LIST = 0x04,
+        NVME_LOG_PAGE_COMMAND_EFFECTS = 0x05,
+        NVME_LOG_PAGE_DEVICE_SELF_TEST = 0x06,
+        NVME_LOG_PAGE_TELEMETRY_HOST_INITIATED = 0x07,
+        NVME_LOG_PAGE_TELEMETRY_CTLR_INITIATED = 0x08,
+        NVME_LOG_PAGE_RESERVATION_NOTIFICATION = 0x80,
+        NVME_LOG_PAGE_SANITIZE_STATUS = 0x81
+      }
+
+      [StructLayout(LayoutKind.Sequential)]
+      internal struct STORAGE_PROTOCOL_SPECIFIC_DATA {
+        public STORAGE_PROTOCOL_TYPE ProtocolType;
+        public uint DataType;
+        public uint ProtocolDataRequestValue;
+        public uint ProtocolDataRequestSubValue;
+        public uint ProtocolDataOffset;
+        public uint ProtocolDataLength;
+        public uint FixedProtocolReturnData;
+        public uint ProtocolDataRequestSubValue2;
+        public uint ProtocolDataRequestSubValue3;
+        public uint Reserved;
+      }
+
+      [StructLayout(LayoutKind.Sequential)]
+      internal struct STORAGE_QUERY_BUFFER {
+
+        public STORAGE_PROPERTY_ID PropertyId;
+        public STORAGE_QUERY_TYPE QueryType;
+        public STORAGE_PROTOCOL_SPECIFIC_DATA ProtocolSpecific;
+
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4096)]
+        internal byte[] Buffer;
+      }
+
+      [DllImport("kernel32.dll", SetLastError = true)]
+      internal static extern void RtlZeroMemory(IntPtr destination, int length);
+
+      /// <summary>
+      /// Create a instance from a struct with zero initialized memory arrays
+      /// no need to init every inner array with the correct sizes
+      /// </summary>
+      /// <typeparam name="T">type of struct that is needed</typeparam>
+      /// <returns></returns>
+      internal static T CreateStruct<T>() {
+        int size = Marshal.SizeOf<T>();
+        IntPtr ptr = Marshal.AllocHGlobal(size);
+        RtlZeroMemory(ptr, size);
+        T result = Marshal.PtrToStructure<T>(ptr);
+        Marshal.FreeHGlobal(ptr);
+        return result;
+      }
     }
   }
 }

--- a/OpenHardwareMonitorLib/Hardware/HDD/WindowsNVMeSmart.cs
+++ b/OpenHardwareMonitorLib/Hardware/HDD/WindowsNVMeSmart.cs
@@ -427,11 +427,6 @@ namespace OpenHardwareMonitor.Hardware.HDD {
       get { return !handle.IsInvalid; }
     }
 
-    public void Close() {
-      Dispose(true);
-      GC.SuppressFinalize(this);
-    }
-
     public NVMeInfo GetInfo(StorageInfo infoToMatch, int logicalDriveNumber) {
       if (handle.IsClosed)
         throw new ObjectDisposedException("WindowsNVMeSmart");
@@ -563,14 +558,16 @@ namespace OpenHardwareMonitor.Hardware.HDD {
 
     #region IDisposable implementation
     public void Dispose() {
-      Close();
+      Dispose(true);
+      GC.SuppressFinalize(this);
     }
     #endregion
 
     protected void Dispose(bool disposing) {
       if (disposing) {
-        if (!handle.IsClosed)
-          handle.Close();
+        handle.Close();
+        handle.Dispose();
+        handle.SetHandleAsInvalid();
       }
     }
 

--- a/OpenHardwareMonitorLib/Hardware/HDD/WindowsNVMeSmart.cs
+++ b/OpenHardwareMonitorLib/Hardware/HDD/WindowsNVMeSmart.cs
@@ -14,7 +14,9 @@ using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
+using Microsoft.Extensions.Logging;
 using Microsoft.Win32.SafeHandles;
+using OpenHardwareMonitorLib;
 
 namespace OpenHardwareMonitor.Hardware.HDD {
 
@@ -434,7 +436,8 @@ namespace OpenHardwareMonitor.Hardware.HDD {
           return new NVMeInfoImpl(driveNumber, logicalDriveNumber, data, rawData, nspace, rawDataNamespace);
         }
         return new NVMeInfoImpl(driveNumber, logicalDriveNumber, data, rawData);
-      } catch (Win32Exception) {
+      } catch (Win32Exception x) {
+        Logging.LogError(x, "Unable to query NVMe controller info");
       }
       return null;
     }

--- a/OpenHardwareMonitorLib/Hardware/HDD/WindowsStorage.cs
+++ b/OpenHardwareMonitorLib/Hardware/HDD/WindowsStorage.cs
@@ -59,7 +59,7 @@ namespace OpenHardwareMonitor.Hardware.HDD {
 
   internal static class WindowsStorage {
     private enum StorageCommand : uint {
-      QueryProperty = 0x002d1400,
+      IOCTL_STORAGE_QUERY_PROPERTY = 0x002d1400,
       IOCTL_STORAGE_GET_DEVICE_NUMBER = 0x002d1080,
     }
 
@@ -187,14 +187,14 @@ namespace OpenHardwareMonitor.Hardware.HDD {
         query.PropertyId = StoragePropertyId.StorageDeviceProperty;
         query.QueryType = StorageQueryType.PropertyStandardQuery;
 
-        if (!NativeMethods.DeviceIoControl(handle, StorageCommand.QueryProperty, ref query,
+        if (!NativeMethods.DeviceIoControl(handle, StorageCommand.IOCTL_STORAGE_QUERY_PROPERTY, ref query,
             Marshal.SizeOf(query), out header, Marshal.SizeOf(typeof(StorageDescriptorHeader)),
             out bytesReturned, IntPtr.Zero))
           return null;
 
         IntPtr descriptorPtr = Marshal.AllocHGlobal((int)header.Size);
         try {
-          if (!NativeMethods.DeviceIoControl(handle, StorageCommand.QueryProperty, ref query,
+          if (!NativeMethods.DeviceIoControl(handle, StorageCommand.IOCTL_STORAGE_QUERY_PROPERTY, ref query,
               Marshal.SizeOf(query), descriptorPtr, header.Size,
               out bytesReturned, IntPtr.Zero))
             return null;

--- a/OpenHardwareMonitorLib/Hardware/Hardware.cs
+++ b/OpenHardwareMonitorLib/Hardware/Hardware.cs
@@ -95,11 +95,6 @@ namespace OpenHardwareMonitor.Hardware {
 
     public event HardwareEventHandler Closing;
 
-    public virtual void Close() {
-      if (Closing != null)
-        Closing(this);
-    }
-
     public void Accept(IVisitor visitor) {
       if (visitor == null)
         throw new ArgumentNullException("visitor");
@@ -112,6 +107,10 @@ namespace OpenHardwareMonitor.Hardware {
     }
 
     protected virtual void Dispose(bool disposing) {
+      if (disposing) {
+        if (Closing != null)
+          Closing(this);
+      }
     }
 
     public void Dispose() {

--- a/OpenHardwareMonitorLib/Hardware/Hardware.cs
+++ b/OpenHardwareMonitorLib/Hardware/Hardware.cs
@@ -14,7 +14,7 @@ using OpenHardwareMonitor.Collections;
 using OpenHardwareMonitorLib;
 
 namespace OpenHardwareMonitor.Hardware {
-  internal abstract class Hardware : IHardware {
+  internal abstract class Hardware : IHardware, IDisposable {
 
     private readonly Identifier identifier;
     protected readonly string name;
@@ -109,6 +109,14 @@ namespace OpenHardwareMonitor.Hardware {
     public virtual void Traverse(IVisitor visitor) {
       foreach (ISensor sensor in active)
         sensor.Accept(visitor);
+    }
+
+    protected virtual void Dispose(bool disposing) {
+    }
+
+    public void Dispose() {
+      Dispose(true);
+      GC.SuppressFinalize(this);
     }
   }
 }

--- a/OpenHardwareMonitorLib/Hardware/Hardware.cs
+++ b/OpenHardwareMonitorLib/Hardware/Hardware.cs
@@ -9,7 +9,9 @@
 */
 
 using System;
+using Microsoft.Extensions.Logging;
 using OpenHardwareMonitor.Collections;
+using OpenHardwareMonitorLib;
 
 namespace OpenHardwareMonitor.Hardware {
   internal abstract class Hardware : IHardware {
@@ -24,6 +26,7 @@ namespace OpenHardwareMonitor.Hardware {
       this.settings = settings;
       this.identifier = identifier;
       this.name = name;
+      Logger = this.GetCurrentClassLogger();
       this.customName = settings.GetValue(
         new Identifier(Identifier, "name").ToString(), name);
     }
@@ -38,6 +41,10 @@ namespace OpenHardwareMonitor.Hardware {
 
     public virtual ISensor[] Sensors {
       get { return active.ToArray(); }
+    }
+
+    protected ILogger Logger {
+      get;
     }
 
     protected virtual void ActivateSensor(ISensor sensor) {

--- a/OpenHardwareMonitorLib/Hardware/Heatmaster/Heatmaster.cs
+++ b/OpenHardwareMonitorLib/Hardware/Heatmaster/Heatmaster.cs
@@ -258,18 +258,15 @@ namespace OpenHardwareMonitor.Hardware.Heatmaster {
       return r.ToString();
     }
 
-    public override void Close() {
-      serialPort.Close();
-      serialPort.Dispose();
-      serialPort = null;
-      base.Close();
-    }
-
-    public void Dispose() {
-      if (serialPort != null) {
+    protected override void Dispose(bool disposing) {
+      if (disposing) {
+        serialPort.Close();
         serialPort.Dispose();
         serialPort = null;
       }
+
+      base.Dispose(disposing);
     }
+    
   }
 }

--- a/OpenHardwareMonitorLib/Hardware/Heatmaster/HeatmasterGroup.cs
+++ b/OpenHardwareMonitorLib/Hardware/Heatmaster/HeatmasterGroup.cs
@@ -166,7 +166,7 @@ namespace OpenHardwareMonitor.Hardware.Heatmaster {
 
     public void Close() {
       foreach (Heatmaster heatmaster in hardware)
-        heatmaster.Close();
+        heatmaster.Dispose();
     }
   }
 }

--- a/OpenHardwareMonitorLib/Hardware/IHardware.cs
+++ b/OpenHardwareMonitorLib/Hardware/IHardware.cs
@@ -8,6 +8,8 @@
 	
 */
 
+using System;
+
 namespace OpenHardwareMonitor.Hardware {
 
   public delegate void SensorEventHandler(ISensor sensor);
@@ -25,7 +27,7 @@ namespace OpenHardwareMonitor.Hardware {
     Network
   }
 
-  public interface IHardware : IElement {
+  public interface IHardware : IElement, IDisposable {
 
     string Name { get; set; }
     Identifier Identifier { get; }

--- a/OpenHardwareMonitorLib/Hardware/Mainboard/Mainboard.cs
+++ b/OpenHardwareMonitorLib/Hardware/Mainboard/Mainboard.cs
@@ -116,7 +116,7 @@ namespace OpenHardwareMonitor.Hardware.Mainboard {
       if (lmSensors != null)
         lmSensors.Close();
       foreach (Hardware hardware in superIOHardware)
-        hardware.Close();
+        hardware.Dispose();
     }
 
     protected virtual void Dispose(bool disposing) {

--- a/OpenHardwareMonitorLib/Hardware/Mainboard/Mainboard.cs
+++ b/OpenHardwareMonitorLib/Hardware/Mainboard/Mainboard.cs
@@ -119,6 +119,17 @@ namespace OpenHardwareMonitor.Hardware.Mainboard {
         hardware.Close();
     }
 
+    protected virtual void Dispose(bool disposing) {
+      if (disposing) {
+        Close();
+      }
+    }
+
+    public void Dispose() {
+      Dispose(true);
+      GC.SuppressFinalize(this);
+    }
+
     public IHardware[] SubHardware {
       get { return superIOHardware; }
     }

--- a/OpenHardwareMonitorLib/Hardware/Mainboard/SuperIOHardware.cs
+++ b/OpenHardwareMonitorLib/Hardware/Mainboard/SuperIOHardware.cs
@@ -1544,12 +1544,12 @@ namespace OpenHardwareMonitor.Hardware.Mainboard {
       postUpdate();
     }
 
-    public override void Close() {
+    protected override void Dispose(bool disposing) {
       foreach (Sensor sensor in controls) {
         // restore all controls back to default
         superIO.SetControl(sensor.Index, null);
       }
-      base.Close();
+      base.Dispose(disposing);
     }
 
     private class Voltage {

--- a/OpenHardwareMonitorLib/Hardware/Network/NetworkGroup.cs
+++ b/OpenHardwareMonitorLib/Hardware/Network/NetworkGroup.cs
@@ -60,7 +60,7 @@ namespace LibreHardwareMonitor.Hardware.Network
             NetworkChange.NetworkAvailabilityChanged -= NetworkChange_NetworkAddressChanged;
 
             foreach (Network network in _hardware)
-                network.Close();
+                network.Dispose();
         }
 
         private void UpdateNetworkInterfaces(ISettings settings)
@@ -90,7 +90,7 @@ namespace LibreHardwareMonitor.Hardware.Network
                 foreach (string key in removeKeys)
                 {
                     var network = _networks[key];
-                    network.Close();
+                    network.Dispose();
                     _networks.Remove(key);
 
                     _hardware.Remove(network);

--- a/OpenHardwareMonitorLib/Hardware/Nvidia/NvidiaGPU.cs
+++ b/OpenHardwareMonitorLib/Hardware/Nvidia/NvidiaGPU.cs
@@ -590,7 +590,7 @@ namespace OpenHardwareMonitor.Hardware.Nvidia {
       NVAPI.NvAPI_GPU_SetCoolerLevels(handle, 0, ref coolerLevels);
     }
 
-    public override void Close() {
+    protected override void Dispose(bool disposing) {
       if (this.fanControl != null) {
         this.fanControl.ControlModeChanged -= ControlModeChanged;
         this.fanControl.SoftwareControlValueChanged -=
@@ -599,7 +599,7 @@ namespace OpenHardwareMonitor.Hardware.Nvidia {
         if (this.fanControl.ControlMode != ControlMode.Undefined)
           SetDefaultFanSpeed();
       }
-      base.Close();
+      base.Dispose(disposing);
     }
   }
 }

--- a/OpenHardwareMonitorLib/Hardware/Nvidia/NvidiaGroup.cs
+++ b/OpenHardwareMonitorLib/Hardware/Nvidia/NvidiaGroup.cs
@@ -108,7 +108,7 @@ namespace OpenHardwareMonitor.Hardware.Nvidia {
 
     public void Close() {
       foreach (Hardware gpu in hardware)
-        gpu.Close();
+        gpu.Dispose();
 
       if (NVML.IsInitialized) {
         NVML.NvmlShutdown();

--- a/OpenHardwareMonitorLib/Hardware/RAM/RAMGroup.cs
+++ b/OpenHardwareMonitorLib/Hardware/RAM/RAMGroup.cs
@@ -39,7 +39,7 @@ namespace OpenHardwareMonitor.Hardware.RAM {
 
     public void Close() {
       foreach (Hardware ram in hardware)
-        ram.Close();
+        ram.Dispose();
     }
   }
 }

--- a/OpenHardwareMonitorLib/Hardware/TBalancer/TBalancer.cs
+++ b/OpenHardwareMonitorLib/Hardware/TBalancer/TBalancer.cs
@@ -316,9 +316,9 @@ namespace OpenHardwareMonitor.Hardware.TBalancer {
       alternativeRequest.BeginInvoke(null, null);
     }
 
-    public override void Close() {
+    protected override void Dispose(bool disposing) {
       FTD2XX.FT_Close(handle);
-      base.Close();
+      base.Dispose(disposing);
     }
 
   }

--- a/OpenHardwareMonitorLib/Hardware/TBalancer/TBalancerGroup.cs
+++ b/OpenHardwareMonitorLib/Hardware/TBalancer/TBalancerGroup.cs
@@ -171,7 +171,7 @@ namespace OpenHardwareMonitor.Hardware.TBalancer {
 
     public void Close() {
       foreach (TBalancer tbalancer in hardware)
-        tbalancer.Close();
+        tbalancer.Dispose();
     }
   }
 }

--- a/OpenHardwareMonitorLib/Logging.cs
+++ b/OpenHardwareMonitorLib/Logging.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace OpenHardwareMonitorLib {
+  public static class Logging {
+    private const string DefaultLoggerName = "Errors";
+    private static object _lock = new object();
+
+    /// <summary>
+    /// The default logger factory for the whole assembly.
+    /// If this is null (the default), logging is disabled
+    /// </summary>
+    public static ILoggerFactory? LoggerFactory { get; set; } = null;
+
+    private static ILogger DefaultLogger { get; set; }
+
+    /// <summary>
+    /// Gets a logger with the given name
+    /// </summary>
+    /// <param name="loggerName">Name of the logger</param>
+    /// <returns>A reference to a <see cref="ILogger"/>.</returns>
+    public static ILogger GetLogger(string loggerName) {
+      if (LoggerFactory == null) {
+        return new NullLogger();
+      }
+
+      return LoggerFactory.CreateLogger(loggerName);
+    }
+
+    /// <summary>
+    /// Gets a logger with the name of the current class
+    /// </summary>
+    /// <param name="currentClass">The class whose logger shall be retrieved</param>
+    /// <returns>A <see cref="ILogger"/> instance</returns>
+    public static ILogger GetCurrentClassLogger(this object currentClass) {
+      string? name = currentClass.GetType().FullName;
+
+      // This is true if the method is used from an incomplete (generic) type
+      if (name == null) {
+        name = currentClass.GetType().Name;
+      }
+
+      return GetLogger(name);
+    }
+
+    public static void LogError(Exception ex, string message) {
+      if (LoggerFactory == null) {
+        return;
+      }
+
+      if (DefaultLogger == null) {
+        DefaultLogger = LoggerFactory.CreateLogger(DefaultLoggerName);
+      }
+
+      DefaultLogger.LogError(ex, message);
+    }
+
+    public static void LogInfo(string message) {
+      if (LoggerFactory == null) {
+        return;
+      }
+
+      if (DefaultLogger == null) {
+        DefaultLogger = LoggerFactory.CreateLogger(DefaultLoggerName);
+      }
+
+      DefaultLogger.LogInformation(message);
+    }
+
+    private class NullLogger : ILogger {
+      public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter) {
+      }
+
+      public bool IsEnabled(LogLevel logLevel) {
+        return false;
+      }
+
+      public IDisposable BeginScope<TState>(TState state) {
+        return new ScopeDisposable();
+      }
+    }
+
+    /// <summary>
+    /// This doesn't really do anything
+    /// </summary>
+    internal sealed class ScopeDisposable : IDisposable {
+      public void Dispose() {
+      }
+    }
+  }
+}

--- a/OpenHardwareMonitorLib/OpenHardwareMonitorLib.csproj
+++ b/OpenHardwareMonitorLib/OpenHardwareMonitorLib.csproj
@@ -22,6 +22,9 @@
     <EmbeddedResource Include="Hardware\WinRing0x64.sys" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="System.Management" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Add logging to places where problems could be hidden
- Try alternate approach for getting NVMe smart data (because the primary approach fails on some older NVMe disks)
- Include the drive letter(s) associated to the physical disks in the name