### PR TITLE
HttpServer: only stop a running server

### DIFF
--- a/OpenHardwareMonitor/Utilities/HttpServer.cs
+++ b/OpenHardwareMonitor/Utilities/HttpServer.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  
   This Source Code Form is subject to the terms of the Mozilla Public
   License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -78,6 +78,9 @@ namespace OpenHardwareMonitor.Utilities {
 
     public Boolean StopHTTPListener() {
       if (PlatformNotSupported)
+        return false;
+
+      if (listenerThread == null)
         return false;
 
       try {


### PR DESCRIPTION
Check if the server is running before trying to stop it since
'StopHTTPListener' is called even if the server may not be running.