### PR TITLE
Fixed multi-GPU NVIDIA memory reporting, fixed null ref in NVMeGeneric

### DIFF
--- a/OpenHardwareMonitor/Properties/AssemblyInfo.cs
+++ b/OpenHardwareMonitor/Properties/AssemblyInfo.cs
@@ -19,7 +19,7 @@ using System.Runtime.Versioning;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Open Hardware Monitor")]
-[assembly: AssemblyCopyright("Copyright © 2009-2021 Michael Möller et al")]
+[assembly: AssemblyCopyright("Copyright © 2009-2022 Michael Möller et al")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: SupportedOSPlatform("windows")]

--- a/OpenHardwareMonitorLib/Hardware/HDD/NVMeGeneric.cs
+++ b/OpenHardwareMonitorLib/Hardware/HDD/NVMeGeneric.cs
@@ -151,7 +151,9 @@ namespace OpenHardwareMonitor.Hardware.HDD {
       r.AppendLine("PCI Vendor ID: 0x" + info.VID.ToString("x04"));
       if (info.VID != info.SSVID)
         r.AppendLine("PCI Subsystem Vendor ID: 0x" + info.VID.ToString("x04"));
-      r.AppendLine("IEEE OUI Identifier: 0x" + info.IEEE[2].ToString("x02") + info.IEEE[1].ToString("x02") + info.IEEE[0].ToString("x02"));
+      if (info.IEEE != null) {
+        r.AppendLine("IEEE OUI Identifier: 0x" + info.IEEE[2].ToString("x02") + info.IEEE[1].ToString("x02") + info.IEEE[0].ToString("x02"));
+      }
       r.AppendLine("Total NVM Capacity: " + info.TotalCapacity);
       r.AppendLine("Unallocated NVM Capacity: " + info.UnallocatedCapacity);
       r.AppendLine("Controller ID: " + info.ControllerId);

--- a/OpenHardwareMonitorLib/Hardware/Nvidia/NVAPI.cs
+++ b/OpenHardwareMonitorLib/Hardware/Nvidia/NVAPI.cs
@@ -205,6 +205,13 @@ namespace OpenHardwareMonitor.Hardware.Nvidia {
   }
 
   [StructLayout(LayoutKind.Sequential, Pack = 8)]
+  internal struct NvGpuMemoryInfo {
+    public uint Version;
+    [MarshalAs(UnmanagedType.ByValArray, SizeConst = NVAPI.MAX_MEMORY_VALUES_PER_GPU)]
+    public uint[] Values;
+  }
+
+  [StructLayout(LayoutKind.Sequential, Pack = 8)]
   internal struct NvDisplayDriverMemoryInfo {
     public uint Version;
     [MarshalAs(UnmanagedType.ByValArray, SizeConst =
@@ -278,6 +285,8 @@ namespace OpenHardwareMonitor.Hardware.Nvidia {
       Marshal.SizeOf(typeof(NvDynamicPstatesInfo)) | 0x10000;
     public static readonly uint GPU_COOLER_SETTINGS_VER = (uint)
       Marshal.SizeOf(typeof(NvGPUCoolerSettings)) | 0x20000;
+    public static readonly uint GPU_MEMORY_INFO_VER = (uint)
+      Marshal.SizeOf(typeof(NvGpuMemoryInfo)) | 0x20000;
     public static readonly uint DISPLAY_DRIVER_MEMORY_INFO_VER = (uint)
       Marshal.SizeOf(typeof(NvDisplayDriverMemoryInfo)) | 0x20000;
     public static readonly uint DISPLAY_DRIVER_VERSION_VER = (uint)
@@ -343,6 +352,10 @@ namespace OpenHardwareMonitor.Hardware.Nvidia {
       ref NvGPUCoolerLevels gpuCoolerLevels);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate NvStatus NvAPI_GPU_GetMemoryInfoDelegate(
+      NvPhysicalGpuHandle gpuHandle, ref NvGpuMemoryInfo memoryInfo);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate NvStatus NvAPI_GetDisplayDriverMemoryInfoDelegate(
       NvDisplayHandle displayHandle, ref NvDisplayDriverMemoryInfo memoryInfo);
 
@@ -396,6 +409,8 @@ namespace OpenHardwareMonitor.Hardware.Nvidia {
       NvAPI_GPU_GetCoolerSettings;
     public static readonly NvAPI_GPU_SetCoolerLevelsDelegate
       NvAPI_GPU_SetCoolerLevels;
+    public static readonly NvAPI_GPU_GetMemoryInfoDelegate
+      NvAPI_GPU_GetMemoryInfo;
     public static readonly NvAPI_GetDisplayDriverMemoryInfoDelegate
       NvAPI_GetDisplayDriverMemoryInfo;
     public static readonly NvAPI_GetDisplayDriverVersionDelegate
@@ -477,6 +492,7 @@ namespace OpenHardwareMonitor.Hardware.Nvidia {
         GetDelegate(0x189A1FDF, out NvAPI_GPU_GetDynamicPstatesInfo);
         GetDelegate(0xDA141340, out NvAPI_GPU_GetCoolerSettings);
         GetDelegate(0x891FA0AE, out NvAPI_GPU_SetCoolerLevels);
+        GetDelegate(0x07F9B368, out NvAPI_GPU_GetMemoryInfo);
         GetDelegate(0x774AA982, out NvAPI_GetDisplayDriverMemoryInfo);
         GetDelegate(0xF951A4D1, out NvAPI_GetDisplayDriverVersion);
         GetDelegate(0x01053FA5, out _NvAPI_GetInterfaceVersionString);

--- a/OpenHardwareMonitorLib/Hardware/Nvidia/NvidiaGPU.cs
+++ b/OpenHardwareMonitorLib/Hardware/Nvidia/NvidiaGPU.cs
@@ -258,12 +258,11 @@ namespace OpenHardwareMonitor.Hardware.Nvidia {
         }
       }
 
-      NvDisplayDriverMemoryInfo memoryInfo = new NvDisplayDriverMemoryInfo();
-      memoryInfo.Version = NVAPI.DISPLAY_DRIVER_MEMORY_INFO_VER;
+      NvGpuMemoryInfo memoryInfo = new NvGpuMemoryInfo();
+      memoryInfo.Version = NVAPI.GPU_MEMORY_INFO_VER;
       memoryInfo.Values = new uint[NVAPI.MAX_MEMORY_VALUES_PER_GPU];
-      if (NVAPI.NvAPI_GetDisplayDriverMemoryInfo != null && displayHandle.HasValue &&
-        NVAPI.NvAPI_GetDisplayDriverMemoryInfo(displayHandle.Value, ref memoryInfo) ==
-        NvStatus.OK) {
+      if (NVAPI.NvAPI_GPU_GetMemoryInfo != null &&
+        NVAPI.NvAPI_GPU_GetMemoryInfo(handle, ref memoryInfo) == NvStatus.OK) {
         uint totalMemory = memoryInfo.Values[0];
         uint freeMemory = memoryInfo.Values[4];
         float usedMemory = Math.Max(totalMemory - freeMemory, 0);
@@ -503,14 +502,12 @@ namespace OpenHardwareMonitor.Hardware.Nvidia {
         r.AppendLine();
       }
 
-      if (NVAPI.NvAPI_GetDisplayDriverMemoryInfo != null && 
-        displayHandle.HasValue) 
+      if (NVAPI.NvAPI_GetDisplayDriverMemoryInfo != null) 
       {
-        NvDisplayDriverMemoryInfo memoryInfo = new NvDisplayDriverMemoryInfo();
-        memoryInfo.Version = NVAPI.DISPLAY_DRIVER_MEMORY_INFO_VER;
+        NvGpuMemoryInfo memoryInfo = new NvGpuMemoryInfo();
+        memoryInfo.Version = NVAPI.GPU_MEMORY_INFO_VER;
         memoryInfo.Values = new uint[NVAPI.MAX_MEMORY_VALUES_PER_GPU];
-        NvStatus status = NVAPI.NvAPI_GetDisplayDriverMemoryInfo(
-          displayHandle.Value, ref memoryInfo);
+        NvStatus status = NVAPI.NvAPI_GPU_GetMemoryInfo(handle, ref memoryInfo);
 
         r.AppendLine("Memory Info");
         r.AppendLine();

--- a/OpenHardwareMonitorLib/Properties/AssemblyInfo.cs
+++ b/OpenHardwareMonitorLib/Properties/AssemblyInfo.cs
@@ -19,7 +19,7 @@ using System.Runtime.Versioning;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Open Hardware Monitor")]
-[assembly: AssemblyCopyright("Copyright © 2009-2021 Michael Möller et al")]
+[assembly: AssemblyCopyright("Copyright © 2009-2022 Michael Möller et al")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: SupportedOSPlatform("windows")]

--- a/OpenHardwareMonitorReport/Properties/AssemblyInfo.cs
+++ b/OpenHardwareMonitorReport/Properties/AssemblyInfo.cs
@@ -18,7 +18,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Open Hardware Monitor")]
-[assembly: AssemblyCopyright("Copyright © 2009-2018 Michael Möller and contributors")]
+[assembly: AssemblyCopyright("Copyright © 2009-2022 Michael Möller and contributors")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Properties/AssemblyVersion.cs
+++ b/Properties/AssemblyVersion.cs
@@ -10,5 +10,5 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("0.10.1.2")]
-[assembly: AssemblyInformationalVersion("0.10.1-alpha2")]
+[assembly: AssemblyVersion("0.10.1.3")]
+[assembly: AssemblyInformationalVersion("0.10.1-alpha3")]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,0 @@
-# openhardwaremonitor
-Open Hardware Monitor - a tool for monitoring hardware performance. Includes support for various temperature sensors, disk I/O ratings and power consumption.
-
-## forked from hexagon-oss/openhardware monitor
-I forked this repo to help keep Open Hardware Monitor updated. Changes committed here may be staged as pull requests in hexagon-oss/openhardware monitor. Please reach out if you're interested in collaborating.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# openhardwaremonitor
+Open Hardware Monitor - a tool for monitoring hardware performance. Includes support for various temperature sensors, disk I/O ratings and power consumption.
+
+## forked from hexagon-oss/openhardware monitor
+I forked this repo to help keep Open Hardware Monitor updated. Changes committed here may be staged as pull requests in hexagon-oss/openhardware monitor. Please reach out if you're interested in collaborating.


### PR DESCRIPTION
Fixed [NVIDIA GPU Memory Stats Misreporting #1386](https://github.com/openhardwaremonitor/openhardwaremonitor/issues/1386) where multiple NVIDIA cards did not show the correct memory. Only the first GPU's memory was shown correctly; all other GPUs simply repeated the exact same details as the first.

This was done by referring to the NVDIA NVAPI and changing the method call from NvAPI_GetDisplayDriverMemoryInfo to NvAPI_GPU_GetMemoryInfo. The former requires a display handle, and in a computer with multiple GPUs that do not have attached displays (VERY common on mining rigs), the display handle value, while not null, is 0x00000000. Therefore the NVAPI was returning the same values as the first GPU. By calling NvAPI_GPU_GetMemoryInfo instead, which takes the GPU hardware handle as a parameter, the correct memory values are returned.

While testing this, I noticed a null reference exception being thrown while trying to generate a report. In NVMeGeneric, there is a line which prints out the info.IEEE array values. However, if info.IEEE is null, there was no null check and a NullReferenceException was thrown and the app would crash.

Below images show the issue as it exists in the alpa-2 build (as well as the 0.9.6 release of Open Hardware monitor, as well as the corrected "0.10.0-alpha3" build in this PR. Values are now represented as expected on the RTX 3060 (12GB) and RTX 2060 (6GB) for memory load, memory free, memory used, memory total.

0.10.0-alpha2/0.9.6 - GPU MEMORY DUPLICATION ISSUE PRESENT
![image](https://user-images.githubusercontent.com/2336742/161401714-eea8bb2c-4d55-4fba-9b25-365faf55dd58.png)

PULL REQUEST 0.10.0-alpha3 - GPU MEMORY SHOWN IS CORRECT
![image](https://user-images.githubusercontent.com/2336742/161400216-7a75198b-ea65-49c5-9571-d9aec4670de9.png)
