### PR TITLE
Fix display of Gadget context menu

### DIFF
--- a/OpenHardwareMonitor/GUI/GadgetWindow.cs
+++ b/OpenHardwareMonitor/GUI/GadgetWindow.cs
@@ -75,9 +75,7 @@ namespace OpenHardwareMonitor.GUI {
     }
 
     private void ShowContextMenu(Point position) {
-      NativeMethods.TrackPopupMenuEx(contextMenu.Handle, 
-        TPM_RIGHTBUTTON | TPM_VERTICAL, position.X,
-        position.Y, Handle, IntPtr.Zero);
+      contextMenu.Show(position, ToolStripDropDownDirection.BelowRight);
     }
 
     protected virtual CreateParams CreateParams {

--- a/OpenHardwareMonitor/GUI/SensorGadget.cs
+++ b/OpenHardwareMonitor/GUI/SensorGadget.cs
@@ -160,8 +160,6 @@ namespace OpenHardwareMonitor.GUI {
       ToolStripMenuItem lockItem = new ToolStripMenuItem("Lock Position and Size");
       contextMenu.Items.Add(lockItem);
       contextMenu.Items.Add(new ToolStripSeparator());
-      ToolStripMenuItem alwaysOnTopItem = new ToolStripMenuItem("Always on Top");
-      contextMenu.Items.Add(alwaysOnTopItem);
       ToolStripMenuItem opacityMenu = new ToolStripMenuItem("Opacity");
       contextMenu.Items.Add(opacityMenu);
       Opacity = (byte)settings.GetValue("sensorGadget.Opacity", 255);      
@@ -185,11 +183,6 @@ namespace OpenHardwareMonitor.GUI {
         Resize();
       };
 
-      alwaysOnTop = new UserOption("sensorGadget.AlwaysOnTop", false, 
-        alwaysOnTopItem, settings);
-      alwaysOnTop.Changed += delegate(object sender, EventArgs e) {
-        this.AlwaysOnTop = alwaysOnTop.Value;
-      };
       lockPositionAndSize = new UserOption("sensorGadget.LockPositionAndSize", 
         false, lockItem, settings);
       lockPositionAndSize.Changed += delegate(object sender, EventArgs e) {


### PR DESCRIPTION
Fixes #33 

Remove "Always on top" from menu, as this option was
moved to the main options menu, because it's useless
when the gadget is not visible.