### PR TITLE
Update IntelCPU.cs

### DIFF
--- a/OpenHardwareMonitorLib/Hardware/CPU/IntelCPU.cs
+++ b/OpenHardwareMonitorLib/Hardware/CPU/IntelCPU.cs
@@ -227,6 +227,7 @@ namespace OpenHardwareMonitor.Hardware.CPU {
                 tjMax = GetTjMaxFromMSR();
                 break;
               case 0x97: //Intel Core 12th
+              case 0x9A: //Intel Core 12th (Mobile)      
                 microarchitecture = Microarchitecture.AlderLake;
                 tjMax = GetTjMaxFromMSR();
                 break;


### PR DESCRIPTION
Adding fammily 0x9A (Intel Core 12th 0x97 is only the Desktop version, Mobile CPU is 0x9A). After the modification, the mobile Adder Lake temperature value is displayed correctly.

![image](https://user-images.githubusercontent.com/104568898/189488756-6028fb6a-fa46-4405-8d92-5f2c8d5531b6.png)
